### PR TITLE
feat: support manual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ Basic Usage:
 - `npx bisect-chrome`
 
 Advanced Usage:
-- `npx bisect-chrome [--good <revision>] [--bad <revision>] [<script>]`
+- `npx bisect-chrome [--manual] [--good <revision>] [--bad <revision>] [<script>]`
 
 Parameters:
+- `--manual`  manually respond with "good" or "bad" instead of running script
 - `--good`    revision that is known to be GOOD. Defaults to the latest revision
 - `--bad`     revision that is known to be BAD. Defaults to 305043
 - `<script>`  path to a Puppeteer script that returns a non-zero code for BAD and 0 for GOOD.
 
 Example:
 - `npx bisect-chrome --good 577361 --bad 599821 simple.js`
+- `npx bisect-chrome --manual --good 577361 --bad 599821`
 
 Use https://omahaproxy.appspot.com/ to find revisions.
 


### PR DESCRIPTION
Turns out it's almost impossible to spawn/bisect on windows unless one
is a proficient BAT-writer: node.js consistently falls back to CMD, and
it's almost impossible to convince it to use git bash and bash script.

This patch is a pragmatic alternative.