### PR TITLE
chore: upgrade to latest pptr

### DIFF
--- a/Launcher.js
+++ b/Launcher.js
@@ -21,7 +21,6 @@ const fs = require('fs');
 const {promisify} = require('util');
 
 const mkdtempAsync = promisify(fs.mkdtemp);
-const removeFolderAsync = promisify(removeFolder);
 
 const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'chrome_bisect_dev_profile-');
 
@@ -101,7 +100,7 @@ class Launcher {
         chromeClosed = true;
         // Cleanup as processes exit.
         if (temporaryUserDataDir) {
-          removeFolderAsync(temporaryUserDataDir)
+          removeFolder(temporaryUserDataDir)
               .then(() => fulfill())
               .catch(err => console.error(err));
         } else {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,13 @@
   "dependencies": {
     "debug": "^4.1.1",
     "minimist": "^1.2.0",
-    "puppeteer-core": "^1.20.0",
+    "progress": "^2.0.3",
+    "puppeteer-core": "^19.7.2",
     "readline": "^1.3.0",
-    "rimraf": "^3.0.0"
+    "rimraf": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/rimraf": "^4.0.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
So after making the changes it turns out that there are no upstream linux/arm64 builds:

```
root@e6c2867e980d:/host# node index.js --bad 1084008 --good 1097615 --shell "echo $CRPATH"
Bisecting 13607 revisions in ~14 iterations
The chromium binary is not available for arm64.
If you are on Ubuntu, you can install with: 

 sudo apt install chromium


 sudo apt install chromium-browser

/host/node_modules/puppeteer-core/lib/cjs/puppeteer/node/BrowserFetcher.js:137
    throw new Error();
          ^

Error
    at handleArm64 (/host/node_modules/puppeteer-core/lib/cjs/puppeteer/node/BrowserFetcher.js:137:11)
    at BrowserFetcher.download (/host/node_modules/puppeteer-core/lib/cjs/puppeteer/node/BrowserFetcher.js:284:13)
    at async downloadRevision (/host/index.js:204:10)
    at async bisect (/host/index.js:122:18)
    at async /host/index.js:109:3
```

So at least we get now a good error message rather than just downloading amd64 on arm64 host.

Closes https://github.com/JoelEinbinder/bisect-chrome/issues/7